### PR TITLE
Fix 

### DIFF
--- a/data/divers/numérique.publicodes
+++ b/data/divers/numérique.publicodes
@@ -57,67 +57,54 @@ divers . numérique . internet . durée journalière:
 # On initialise les options que l'on veut voir apparaître dans la mosaïque
 divers . numérique . appareils . mosaic . téléphone . choix:
   titre: "téléphone"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 📱
 
 divers . numérique . appareils . mosaic . TV . choix:
   titre: "TV"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 📺
 
 divers . numérique . appareils . mosaic . ordinateur portable . choix:
   titre: "ordinateur portable"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 💻
 
 divers . numérique . appareils . mosaic . ordinateur fixe . choix:
   titre: "ordinateur fixe"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 🖥
 
 divers . numérique . appareils . mosaic . tablette . choix:
   titre: "tablette"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: ⬛
 
 divers . numérique . appareils . mosaic . vidéoprojecteur . choix:
   titre: "vidéoprojecteur"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 📽️
 
 divers . numérique . appareils . mosaic . appareil photo . choix:
   titre: "appareil photo"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 📷
 
 divers . numérique . appareils . mosaic . home cinéma . choix:
   titre: "home cinéma"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 🔊🎬
 
 divers . numérique . appareils . mosaic . enceinte bluetooth . choix:
   titre: "enceinte bluetooth"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 🎵
 
 divers . numérique . appareils . mosaic . enceinte vocale . choix:
   titre: "enceinte vocale"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 🔊
 
 divers . numérique . appareils . mosaic . montre connectée . choix:
   titre: "montre connectée"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: ⌚️
 
 divers . numérique . appareils . mosaic . console de salon . choix:
   titre: "console de salon"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 🕹
 
 divers . numérique . appareils . mosaic . console portable . choix:
   titre: "console portable"
-  question: "l'avez-vous acheté l'année dernière ?"
   icônes: 🎮
 
 # On redéfinit les options que l'on veut voir apparaître dans la mosaïque.
@@ -269,13 +256,14 @@ divers . numérique . appareils . mosaic . console portable:
 
 # On définit notre mosaïque en réutilisant les infos définis plus haut
 divers . numérique . appareils . mosaic:
+  applicable si: divers . numérique . appareils . nombre total > 0
   mosaique:
     type: nombre
     optionsConditionnelles:
       - téléphone . choix . nombre
       - TV . choix . nombre
       - ordinateur portable . choix . nombre
-      - ordinateur . choix fixe . nombre
+      - ordinateur fixe . choix . nombre
       - tablette . choix . nombre
       - vidéoprojecteur . choix . nombre
       - appareil photo . choix . nombre


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

+ Retrait des questions dans l'initialisations des questions mosaiques
+ Erreur de syntaxe sur l'ordinateur fixe
+ Ajout d'une condition pour afficher la question mosaique que lorsqu'il y a plus d'un objet selectionné

:watermelon: Implémentation
----
+ Dans le fichier `numérique.publicods` on a utilise le mécanisme `utilisable si` pour gérer le cas si aucune réponse n'a été choisie
+ Le retrait des questions dans l'initialisation permet de ne pas les afficher dans le formulaire

:tada: Axes d'améliorations
----
+ A creuser si on ne peut pas se passer de cette initialisation

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)